### PR TITLE
Feature: Lucky winner picker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 DISCORD_TOKEN = your_discord_token_here
 HUGGING_FACE = your_hugging_face_token_here
 GOOGLE_API_KEY = your_google_api_key_here
+
+# Credentials for viewing the logs
 USERNAME = your_username_here
 PASSWORD = your_password_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-venv*
+*venv*
 .env
 vectorstore/
 *.log

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ USERNAME = username  ### for viewing the logs
 PASSWORD = password  ### for viewing the logs
 ```
 
+> [!IMPORTANT]
+> Ensure your `DISCORD_TOKEN` has _Privileged Gateway Intents_
+
 ## Usage
 
 1. First, run the article fetching script to create the knowledge base:

--- a/lucky_picker.py
+++ b/lucky_picker.py
@@ -1,6 +1,22 @@
 import random
 
 def pick_lucky_winner(range: str, count: int, seed : int, exclude: str):
+    """Picks lucky number(s) from a given range
+
+    Parameters:
+        range (str): Range of numbers to choose from. Provided in `x-y` format. Both numbers are included as possible winners.
+        count (int): Number of lucky winners. _Must be more than 1._
+        seed (int): Seed to initialse random. _Must not be `None`._
+        exclude (str): Comma-seperated list of numbers to exclude from the winners. Format: `x1,x2,x3,...`
+
+    Returns:
+        tuple: A tuple containing three values:
+            - error (str): Message of error faced.
+            - winners (list): List of strings of the winning numbers.
+            - seed_used (int): The seed used in the random picking.
+        If error, then `winners` and `seed_used` would be `None`.
+        Similarly, when `winners` and `seed_used`, then `error` would be `None`.
+    """
     assert seed is not None
     assert count >= 1
 
@@ -51,4 +67,5 @@ def pick_lucky_winner(range: str, count: int, seed : int, exclude: str):
     return None, winners, seed
 
 def get_random_seed() -> int:
+    """Randomly generate a number between 1 and 500 to be used as a seed."""
     return random.randint(1, 500)

--- a/lucky_picker.py
+++ b/lucky_picker.py
@@ -25,6 +25,8 @@ def pick_lucky_winner(range: str, count: int, seed : int, exclude: str):
     
     # Validate range
     range = range.split('-')
+    range = list(map(str.strip, range)) # clean up whitespace
+    range = [x for x in range if len(x) > 0] # drop empty string
     if len(range) != 2:
         return "Please provide range in format `x-y`.", None, None
     if range[0] == range[1]:

--- a/lucky_picker.py
+++ b/lucky_picker.py
@@ -1,0 +1,54 @@
+import random
+
+def pick_lucky_winner(range: str, count: int, seed : int, exclude: str):
+    assert seed is not None
+    assert count >= 1
+
+    if not range.strip():
+        return "Please provide a range.", None, None
+    
+    # Validate range
+    range = range.split('-')
+    if len(range) != 2:
+        return "Please provide range in format `x-y`.", None, None
+    if range[0] == range[1]:
+        return "In range `x-y`, `x` and `y` cannot be the same.", None, None
+    if not all(map(str.isdigit, range)):
+        return "In range `x-y`, both `x` and `y` must be digits.", None, None
+    range = [int(x) for x in range] # cast to int
+    
+    # Validate exclude
+    if exclude.strip():
+        exclude = exclude.split(',')
+        exclude = list(map(str.strip, exclude)) # clean up whitespace
+        if not all(map(str.isdigit, exclude)):
+            return "In exclude `x1,x2,x3,...`, all `x` must be digit.", None, None
+        exclude = list(set(exclude)) # get unique
+        exclude = [int(x) for x in exclude] # cast to int
+    else:
+        exclude = []
+    
+    start_range, end_range = min(range), max(range)
+
+    # Validate count
+    soft_limit = (end_range - start_range + 1) - len(exclude)
+    count = min(soft_limit, count)
+    if count > 100:  # Sanity limit
+        return "Really? That's a really big range. I'm not doing it >:(", None, None
+
+    # Logic to select lucky winners
+
+    winners = []
+    random.seed(seed)
+
+    while len(winners) != count:
+        candidate = random.randint(start_range, end_range)
+        if candidate not in exclude and candidate not in winners:
+            winners.append(candidate)
+
+    winners.sort()
+    winners = list(map(str, winners)) # cast to str
+    return None, winners, seed
+
+def get_random_seed() -> int:
+    return random.randint(1, 500)

--- a/lucky_picker.py
+++ b/lucky_picker.py
@@ -21,8 +21,8 @@ def pick_lucky_winner(range: str, count: int, seed : int, exclude: str):
     if exclude.strip():
         exclude = exclude.split(',')
         exclude = list(map(str.strip, exclude)) # clean up whitespace
-        if not all(map(str.isdigit, exclude)):
-            return "In exclude `x1,x2,x3,...`, all `x` must be digit.", None, None
+        exclude = [x for x in exclude if len(x) > 0] # drop empty string
+        exclude = [x for x in exclude if x.isdigit()] # drop non-digits
         exclude = list(set(exclude)) # get unique
         exclude = [int(x) for x in exclude] # cast to int
     else:

--- a/main.py
+++ b/main.py
@@ -210,6 +210,11 @@ async def help_command(interaction: discord.Interaction):
         value="Calculate the estimated date to receive your withdrawal",
         inline=False,
     )
+    embeded.add_field(
+        name="/lucky_winner",
+        value="Pick lucky winners randomly",
+        inline=False,
+    )
     embeded.add_field(name="/help", value="Help Command", inline=False)
     embeded.set_thumbnail(url="attachment://su-pfp.png")
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import calendar
 from pathlib import Path
 from datetime import datetime, timedelta
 from keep_alive import keep_alive
+from lucky_picker import pick_lucky_winner, get_random_seed
 from dotenv import load_dotenv
 from discord.ext import commands
 from discord import app_commands
@@ -295,6 +296,33 @@ async def calculate_withdrawal(interaction: discord.Interaction, withdrawal_date
         logging.error(f"Error in 'calculate_withdrawal' command: {e}")
         await interaction.response.send_message(
             "An error occurred while calculating the withdrawal date. Please try again later."
+        )
+
+@bot.tree.command(
+        name="lucky_winner", description="Randomly pick lucky winner(s)"
+)
+@app_commands.describe(
+    range="Range of numbers to choose from. Provided as `1-10`. Both numbers are included as possible winners.",
+    count="Number of lucky winners. Defaults to 1 if not provided.",
+    seed="Seed for the randomizer. If not provided, a random will be generated.",
+    exclude="Number(s) to exclude from the pick. Provided as a list: `1,2,3`."
+)
+async def lucky_winner(interaction: discord.Interaction, range: str, count: int = 1, seed: int = None, exclude: str = ''):
+    if seed is None:
+        seed = get_random_seed()
+
+    error, winners, seed_used = pick_lucky_winner(range, count, seed, exclude)
+
+    if error:
+        await interaction.response.send_message(f"{error}")
+    else:
+        logging.info(
+            f"Lucky winner request by {interaction.user.name} in #{interaction.channel}, "
+            f"for range {range} excluding {exclude if len(exclude) > 1 else None} using seed {seed} "
+            f"yields {count} winner(s): {winners}"
+        )
+        await interaction.response.send_message(
+            f"The lucky winners {"is" if len(winners) == 1 else "are"} {", ".join(winners)}.\n-# Seed used: {seed_used}"
         )
 
 


### PR DESCRIPTION
This implements `/lucky_winner` to randomly pick lucky winners for quizzes.

`/lucky_winner` requires the following parameter:
- `range`: Range of numbers to choose from. 
  - Provide as `x-y`. 
  - Both numbers `x` and `y` are included as possible winners.
  - eg. `11 - 30` will randomly pick from 11 to 30, with both 11 and 30 being included.
  - `y-x` will internally be swapped to `x-y` if `y > x` (Hence, `30-11` is also valid)
 
Optionally, `/lucky_winner` can also take in the following parameters:
- `count`: Number of lucky winners. 
  - Defaults to 1 if not provided.
- `seed`: "Seed for the randomizer. 
  - If not provided, a random will be generated.
- `exclude`: Number(s) to exclude from the pick. Provided as a list: `x1,x2,x3,...`.
  - If not provided, nothing is excluded.
  - invalid entries will be ignore (Eg. `1, 2, three,  , 4` will only exclude `1`, `2` and `4`)
  
---
Note: 
`/lucky_winner` will _not_ attempt to pick more than 100 winners.