### PR TITLE
Bugfix: improve lucky_winner logic

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,9 +1,0 @@
-import discord
-
-GIVE_DEV_PERMISSIONS = False  # Must be 'False' in production
-
-valid_role_ids = [968790212140466206, 1062482414271737897]
-
-def check_has_role(user: discord.Member) -> bool:
-    return GIVE_DEV_PERMISSIONS or\
-        any(user_role.id in valid_role_ids for user_role in user.roles)

--- a/admin.py
+++ b/admin.py
@@ -1,0 +1,9 @@
+import discord
+
+GIVE_DEV_PERMISSIONS = False  # Must be 'False' in production
+
+valid_role_ids = [968790212140466206, 1062482414271737897]
+
+def check_has_role(user: discord.Member) -> bool:
+    return GIVE_DEV_PERMISSIONS or\
+        any(user_role.id in valid_role_ids for user_role in user.roles)

--- a/auth_admin.py
+++ b/auth_admin.py
@@ -1,0 +1,37 @@
+import discord
+
+
+GIVE_DEV_PERMISSIONS = False  # Must be 'False' in production
+
+
+valid_role_ids = [968790212140466206, 1062482414271737897]
+
+
+def check_if_owner(intraction: discord.Interaction) -> bool:
+    """
+    Checks if the user of the interaction is 
+    the owner of the guild which the interaction came from
+    """
+    return intraction.user == intraction.guild.owner
+
+
+def check_admin_permission(user: discord.Member) -> bool:
+    """
+    Checks if user has Administrator permission
+    
+    The permission allows all permissions and bypasses channel permission overwrites.
+    """
+    return user.resolved_permissions.administrator
+
+
+def check_has_role(user: discord.Member) -> bool:
+    """Check if user has any of the white-listed valid roles"""
+    return any(user_role.id in valid_role_ids for user_role in user.roles)
+
+
+def check_has_permissions(interaction: discord.Interaction) -> bool:
+    """Checks if user of interaction has privilege"""
+    return check_if_owner(interaction) or\
+        check_admin_permission(interaction.user) or\
+        check_has_role(interaction.user) or\
+        GIVE_DEV_PERMISSIONS

--- a/lucky_picker.py
+++ b/lucky_picker.py
@@ -35,6 +35,8 @@ def pick_lucky_winner(range: str, count: int, seed: int, exclude: str):
         return "In range `x-y`, both `x` and `y` must be digits.", None, None
     range = [int(x) for x in range]  # cast to int
 
+    start_range, end_range = min(range), max(range)
+
     # Validate exclude
     if exclude.strip():
         exclude = exclude.split(",")
@@ -43,24 +45,23 @@ def pick_lucky_winner(range: str, count: int, seed: int, exclude: str):
         exclude = [x for x in exclude if x.isdigit()]  # drop non-digits
         exclude = list(set(exclude))  # get unique
         exclude = [int(x) for x in exclude]  # cast to int
+        exclude = [x for x in exclude if x >= start_range and x <= end_range]  # drop not-in-range
     else:
         exclude = []
-
-    start_range, end_range = min(range), max(range)
 
     # Validate count
     soft_limit = (end_range - start_range + 1) - len(exclude)
     count = min(soft_limit, count)
-    if count <= 0:
-        return "There's no winner to pick.", None, None
+    if soft_limit <= 0:
+        return "You have excluded everyone. Who do you want me to pick?", None, None
+    elif count <= 0:
+        return f"I can't pick {count} winner(s).", None, None
     elif count > 100:  # Sanity limit
         return "Really? That's a really big range. I'm not doing it >:(", None, None
 
     # Logic to select lucky winners
-
     winners = []
     random.seed(seed)
-
     while len(winners) != count:
         candidate = random.randint(start_range, end_range)
         if candidate not in exclude and candidate not in winners:

--- a/lucky_picker.py
+++ b/lucky_picker.py
@@ -6,7 +6,7 @@ def pick_lucky_winner(range: str, count: int, seed: int, exclude: str):
 
     Parameters:
         range (str): Range of numbers to choose from. Provided in `x-y` format. Both numbers are included as possible winners.
-        count (int): Number of lucky winners. _Must be more than 1._
+        count (int): Number of lucky winners. Should be more than 1.
         seed (int): Seed to initialse random. _Must not be `None`._
         exclude (str): Comma-seperated list of numbers to exclude from the winners. Format: `x1,x2,x3,...`
 
@@ -19,7 +19,6 @@ def pick_lucky_winner(range: str, count: int, seed: int, exclude: str):
         Similarly, when `winners` and `seed_used`, then `error` would be `None`.
     """
     assert seed is not None
-    assert count >= 1
 
     if not range.strip():
         return "Please provide a range.", None, None
@@ -52,7 +51,9 @@ def pick_lucky_winner(range: str, count: int, seed: int, exclude: str):
     # Validate count
     soft_limit = (end_range - start_range + 1) - len(exclude)
     count = min(soft_limit, count)
-    if count > 100:  # Sanity limit
+    if count <= 0:
+        return "There's no winner to pick.", None, None
+    elif count > 100:  # Sanity limit
         return "Really? That's a really big range. I'm not doing it >:(", None, None
 
     # Logic to select lucky winners

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import json
 import discord
 import logging
 import calendar
+import admin
 from pathlib import Path
 from datetime import datetime, timedelta
 from keep_alive import keep_alive
@@ -315,12 +316,7 @@ async def lucky_winner(
     seed: int = None,
     exclude: str = "",
 ):
-    valid_role_ids = [968790212140466206, 1062482414271737897]
-    has_role = any(
-        user_role.id in valid_role_ids for user_role in interaction.user.roles
-    )
-
-    if has_role:
+    if admin.check_has_role(interaction.user):
         if seed is None:
             seed = get_random_seed()
 

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import json
 import discord
 import logging
 import calendar
-import admin
+import auth_admin
 from pathlib import Path
 from datetime import datetime, timedelta
 from keep_alive import keep_alive
@@ -316,7 +316,7 @@ async def lucky_winner(
     seed: int = None,
     exclude: str = "",
 ):
-    if admin.check_has_role(interaction.user):
+    if auth_admin.check_has_permissions(interaction):
         if seed is None:
             seed = get_random_seed()
 

--- a/main.py
+++ b/main.py
@@ -327,6 +327,11 @@ async def lucky_winner(
         error, winners, seed_used = pick_lucky_winner(range, count, seed, exclude)
 
         if error:
+            logging.info(
+                f"Lucky winner request by {interaction.user.name} in #{interaction.channel}, "
+                f"for range {range} excluding {exclude if len(exclude) > 1 else None} using seed {seed} for {count} winner(s) "
+                f"gives error: {error}"
+            )
             await interaction.response.send_message(f"{error}")
         else:
             logging.info(

--- a/prod_test.py
+++ b/prod_test.py
@@ -1,0 +1,12 @@
+import unittest
+from auth_admin import GIVE_DEV_PERMISSIONS
+
+
+class Production(unittest.TestCase):
+
+    def test_no_dev_permissions(self):
+        self.assertFalse(GIVE_DEV_PERMISSIONS)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**lucky_winner**
- Log error(s) throw by `/lucky_winner`
- Fix bug where `exclude` may possibly reduce `count` to less than 1
- Handle issue when `exclude` list contains not-in-range numbers, which will reduce the soft limit on `count`, even though it should not affect `count`

**Misc**
- Abstract code for authorization of commands (using roles/permissions) into its own file, to allow ease of reuse (DRY principle)
- Update to give server owner authorization (owner should always be authorized)
- Update to give server administrators authorization (administrators should always be authorized)
  - ![image](https://github.com/user-attachments/assets/a1fe9ba3-0dd9-4a7d-995f-a8c262f448e7)
  - Respect Discord's concept that administrators should have *every* permission
- Add small unit test to ensure that the flag to give developer permissions (for testing) is not enabled when pushed to production

---
Future plans:
Integrate with GitHub Actions to automatically run unit tests when committing/PR merge
