### PR TITLE
Feature/open ticket helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 vectorstore/
 *.log
 __pycache__
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-venv*
+*venv*
 .env
 vectorstore/
 *.log

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from datetime import datetime, timedelta
 from keep_alive import keep_alive
 from lucky_picker import pick_lucky_winner, get_random_seed
+from ticket_helper import TicketHelper, start_ticket_embed
 from dotenv import load_dotenv
 from discord.ext import commands
 from discord import app_commands
@@ -299,6 +300,11 @@ async def calculate_withdrawal(interaction: discord.Interaction, withdrawal_date
             "An error occurred while calculating the withdrawal date. Please try again later.",
             ephemeral=True,
         )
+
+
+@bot.tree.command(name="ticket", description="Open a new ticket")
+async def ticket(interaction: discord.Interaction):
+    await interaction.response.send_message(view=TicketHelper(), embed=start_ticket_embed, ephemeral=True)
 
 
 @bot.tree.command(name="lucky_winner", description="Randomly pick lucky winner(s)")

--- a/ticket_helper.py
+++ b/ticket_helper.py
@@ -2,7 +2,9 @@ import discord
 
 
 base_url = "https://stackuphelpcentre.zendesk.com/hc/en-us/requests/new"
-
+command_calculate_withdrawal = "</calculate_withdrawal:???>" # not used because unknown command ID
+channel_bug_error_report = "<#968395739619278890>"
+channel_re_review_submission = "<#1067468094190129232>"
 
 start_ticket_embed = discord.Embed(
     title="Submit a request",
@@ -140,8 +142,8 @@ class StateMachine:
             .insert_branch_state("platform_bug")
 
             .insert_next_state("suggest_discord")
-            .update_content("You can report in #bug-error-report.")
-            .update_data("next-action", "Open official report")
+            .update_content(f"You can report in {channel_bug_error_report}.")
+            .update_data("next-action", "Submit official report")
 
             .insert_next_state("open_ticket")
             .update_content("You should open a ticket.")
@@ -152,11 +154,11 @@ class StateMachine:
             .insert_branch_state("submission_related")
 
             .insert_next_state("suggest_discord_channel")
-            .update_content("Have you checked recent #re-review submission for similar issues reported?")
+            .update_content(f"Have you checked recent {channel_re_review_submission} for similar issues reported?")
             .update_data("next-action", "Yes")
 
             .insert_next_state("suggest_discord_discussion")
-            . update_content("Have you discussed with other stackies in #re-review submission?")
+            . update_content(f"Have you discussed with other stackies in {channel_re_review_submission}?")
             .update_data("next-action", "Yes")
 
             .insert_next_state("open_ticket")

--- a/ticket_helper.py
+++ b/ticket_helper.py
@@ -28,6 +28,14 @@ class State:
         self.next = new_state
         new_state.prev = self
         return new_state
+    
+
+    def insert_branch_state(self, state_name):
+        """insert and returns this state object"""
+        new_state = State(state_name)
+        self.branch[state_name] = new_state
+        new_state.prev = self
+        return new_state
 
 
     def update_content(self, content):
@@ -60,17 +68,22 @@ class StateMachine:
     current_state = None
 
     """
-    states = (
-        "start",
-        ("issue_type", (
-            ("general_enquiry", "open_ticket=9094359542041"),
-            ("account_related", "open_ticket=10970588074137"),
-            ("withdrawal_related", "check_processing_days", "open_ticket=11749552676121"),
-
-            ("platform_bug", "suggest_discord", "open_ticket=11733831427737"),
-            ("submission_related", "suggest_discord", "open_ticket=11733869435673")
-        )),
-    )
+    States:
+    ├ start
+    └ issue_type
+      ├ general_enquiry
+      | └ open_ticket = 9094359542041
+      ├ account_related
+      | └ open_ticket = 10970588074137
+      ├ withdrawal_related
+      | ├ check_processing_days
+      | └ open_ticket = 11749552676121
+      ├ platform_bug
+      | ├ suggest_discord
+      | └ open_ticket = 11733831427737
+      └ submission_related
+        ├ suggest_discord
+        └ open_ticket = 11733869435673
     """
 
 
@@ -87,38 +100,35 @@ class StateMachine:
         self.start_state = State("start")
         branch_state = self.start_state.insert_next_state("issue_type").update_content("Choose your issue type:")
 
-        state_1 = State("general_enquiry")
-        state_1.prev = branch_state
-        state_1.insert_next_state("open_ticket").update_data("ticket-id", "9094359542041")
-        branch_state.branch["general_enquiry"] = state_1
+        (branch_state
+            .insert_branch_state("general_enquiry")
+            .insert_next_state("open_ticket")
+            .update_content("You should open a ticket.")
+            .update_data("ticket-id", "9094359542041")
+        )
 
-        state_2 = State("account_related")
-        state_2.prev = branch_state
-        state_2.insert_next_state("open_ticket").update_data("ticket-id", "10970588074137")
-        branch_state.branch["account_related"] = state_2
+        (branch_state
+            .insert_branch_state("account_related")
+            .insert_next_state("open_ticket")
+            .update_data("ticket-id", "10970588074137")
+        )
 
-        state_3 = State("withdrawal_related")
-        state_3.prev = branch_state
-        state_3\
-            .insert_next_state("check_processing_days")\
-            .insert_next_state("open_ticket").update_data("ticket-id", "11749552676121")
-        branch_state.branch["withdrawal_related"] = state_3
+        (branch_state
+            .insert_branch_state("withdrawal_related")
+            .insert_next_state("check_processing_days")
+            .insert_next_state("open_ticket")
+            .update_data("ticket-id", "11749552676121")
+        )
 
-        state_4 = State("platform_bug")
-        state_4.prev = branch_state
-        (
-        state_4
+        (branch_state
+            .insert_branch_state("platform_bug")
             .insert_next_state("suggest_discord")
-            .update_content("content content")
             .insert_next_state("open_ticket")
             .update_data("ticket-id", "11733831427737")
         )
-        branch_state.branch["platform_bug"] = state_4
 
-        state_5 = State("submission_related").update_content("### Submission-Related Matters")
-        state_5.prev = branch_state
-        (
-        state_5
+        (branch_state
+            .insert_branch_state("submission_related")
             .insert_next_state("suggest_discord")
             .update_content(
                 "- Have you checked recent #re-review submission for similar issues reported?\n"
@@ -127,7 +137,6 @@ class StateMachine:
             .insert_next_state("open_ticket")
             .update_data("ticket-id", "11733869435673")
         )
-        branch_state.branch["submission_related"] = state_5
 
         self.current_state = self.start_state
 

--- a/ticket_helper.py
+++ b/ticket_helper.py
@@ -1,0 +1,263 @@
+import discord
+
+
+base_url = "https://stackuphelpcentre.zendesk.com/hc/en-us/requests/new"
+
+
+start_ticket_embed = discord.Embed(
+    title="Submit a request",
+    description="Jumpstart on opening a ticket",
+    url=base_url)
+
+
+class State:
+
+
+    def __init__(self, name):
+        self.name = name
+        self.content = ""
+        self.data: dict = {}
+        self.prev: State = None
+        self.next: State = None
+        self.branch: dict = {}
+
+
+    def insert_next_state(self, state_name):
+        """insert and returns this state object"""
+        new_state = State(state_name)
+        self.next = new_state
+        new_state.prev = self
+        return new_state
+
+
+    def update_content(self, content):
+        """update this state's data, and return this state object"""
+        self.content = content
+        return self
+    
+
+    def update_data(self, key, value):
+        self.data[key] = value
+        return self
+    
+
+    def remove_data(self, key):
+        self.data.popitem(key)
+        return self
+    
+
+    def has_next(self):
+        return self.next is not None or len(self.branch) > 0
+
+
+    def has_prev(self):
+        return self.prev is not None
+
+
+class StateMachine:
+
+    start_state = None
+    current_state = None
+
+    """
+    states = (
+        "start",
+        ("issue_type", (
+            ("general_enquiry", "open_ticket=9094359542041"),
+            ("account_related", "open_ticket=10970588074137"),
+            ("withdrawal_related", "check_processing_days", "open_ticket=11749552676121"),
+
+            ("platform_bug", "suggest_discord", "open_ticket=11733831427737"),
+            ("submission_related", "suggest_discord", "open_ticket=11733869435673")
+        )),
+    )
+    """
+
+
+    issue_type_options = {
+        "General Enquiry": "general_enquiry",
+        "Withdrawal-Related Matters": "withdrawal_related",
+        "Submission-Related Matters": "submission_related",
+        "Account-Related Matters": "account_related",
+        "Platform Bug Issue": "platform_bug"
+    }
+
+
+    def __init__(self):
+        self.start_state = State("start")
+        branch_state = self.start_state.insert_next_state("issue_type").update_content("Choose your issue type:")
+
+        state_1 = State("general_enquiry")
+        state_1.prev = branch_state
+        state_1.insert_next_state("open_ticket").update_data("ticket-id", "9094359542041")
+        branch_state.branch["general_enquiry"] = state_1
+
+        state_2 = State("account_related")
+        state_2.prev = branch_state
+        state_2.insert_next_state("open_ticket").update_data("ticket-id", "10970588074137")
+        branch_state.branch["account_related"] = state_2
+
+        state_3 = State("withdrawal_related")
+        state_3.prev = branch_state
+        state_3\
+            .insert_next_state("check_processing_days")\
+            .insert_next_state("open_ticket").update_data("ticket-id", "11749552676121")
+        branch_state.branch["withdrawal_related"] = state_3
+
+        state_4 = State("platform_bug")
+        state_4.prev = branch_state
+        (
+        state_4
+            .insert_next_state("suggest_discord")
+            .update_content("content content")
+            .insert_next_state("open_ticket")
+            .update_data("ticket-id", "11733831427737")
+        )
+        branch_state.branch["platform_bug"] = state_4
+
+        state_5 = State("submission_related").update_content("### Submission-Related Matters")
+        state_5.prev = branch_state
+        (
+        state_5
+            .insert_next_state("suggest_discord")
+            .update_content(
+                "- Have you checked recent #re-review submission for similar issues reported?\n"
+                "- Have you discussed with other stackies in #re-review submission?"
+            )
+            .insert_next_state("open_ticket")
+            .update_data("ticket-id", "11733869435673")
+        )
+        branch_state.branch["submission_related"] = state_5
+
+        self.current_state = self.start_state
+
+
+    def prev_state(self):
+        """move to previous state"""
+        self.current_state = self.current_state.prev
+
+    def next_state(self, branch = None):
+        """move to next state"""
+
+        if branch:
+            self.current_state = self.current_state.branch[branch]
+        else:
+            self.current_state = self.current_state.next
+
+        if self.current_state.content == "":
+            self.next_state()
+
+
+class TicketHelper(discord.ui.View):
+
+    state_machine: StateMachine = None
+    embed = None
+    content = ""
+
+    def load_state_ui(self):
+        state = self.state_machine.current_state
+
+        self.content = state.content
+        self.embed = start_ticket_embed if state.name == "start" else None
+        self.clear_items()
+
+        if state.name == "issue_type":
+            print('create')
+            self.branch_select = discord.ui.Select(placeholder="Issue Type", options=
+                    list(map(lambda x: discord.SelectOption(label=x), StateMachine.issue_type_options)))
+            self.branch_select.callback = self.branch_next_state
+            self.add_item(self.branch_select)
+            self.next_btn.disabled = True
+        else:
+            self.branch_select = None
+        
+        if state.has_prev():
+            self.add_item(self.back_btn)
+        if state.has_next() and state.name != "issue_type":
+            self.add_item(self.next_btn)
+
+        if state.name == "open_ticket":
+            ticket_form_id = state.data["ticket-id"]
+            self.link_btn.url = f"{base_url}?ticket_form_id={ticket_form_id}" if ticket_form_id else base_url
+            self.add_item(self.link_btn)
+
+        ############################## TESTING ##############################
+        #self.add_item(self.check_btn)
+        ############################## TESTING ##############################
+
+
+    def __init__(self):
+        super().__init__()
+
+        self.state_machine = StateMachine()
+
+        self.back_btn = discord.ui.Button(label="Back", style=discord.ButtonStyle.grey, row=4)
+        self.back_btn.callback = self.go_prev_state
+
+        self.next_btn = discord.ui.Button(label="Proceed",style=discord.ButtonStyle.blurple, row=4)
+        self.next_btn.callback = self.go_next_state
+
+        self.link_btn = discord.ui.Button(label="Open Ticket",style=discord.ButtonStyle.link, row=4, url=base_url)
+
+        ############################## TESTING ##############################
+        # async def check_curr_state(interaction: discord.Interaction):
+        #    await interaction.response.edit_message(content=self.state_machine.current_state.name)
+            
+        # self.check_btn = discord.ui.Button(label="Check",style=discord.ButtonStyle.danger)
+        # self.check_btn.callback = check_curr_state
+
+
+        self.state_machine.next_state()
+        ############################## TESTING ##############################
+
+        self.load_state_ui()
+
+
+    async def go_prev_state(self, interaction: discord.Interaction):
+        self.state_machine.prev_state()
+        self.load_state_ui()
+
+        await interaction.response.edit_message(
+            content=self.content,
+            embed=self.embed,
+            view=self)
+
+
+    async def go_next_state(self, interaction: discord.Interaction):
+        self.state_machine.next_state()
+        self.load_state_ui()
+
+        await interaction.response.edit_message(
+            content=self.content,
+            embed=self.embed,
+            view=self)
+    
+
+    async def branch_next_state(self, interaction: discord.Interaction):
+        selected_issue_type = self.branch_select.values[0]
+        select_branch_state = StateMachine.issue_type_options[selected_issue_type]
+        
+        print(select_branch_state)
+        
+        #"""
+
+        self.state_machine.next_state(select_branch_state)
+        self.load_state_ui()
+
+        await interaction.response.edit_message(
+            content=self.content,
+            embed=self.embed,
+            view=self)
+
+        """#
+        # FIXME: preferbly, selection option does not go next state immedtately,
+        #        but it enables the proceed button instead
+
+        self.next_btn.disabled = False
+        
+        await interaction.response.defer()
+
+        #"""
+
+
+        

--- a/ticket_helper.py
+++ b/ticket_helper.py
@@ -145,16 +145,21 @@ class StateMachine:
         """move to previous state"""
         self.current_state = self.current_state.prev
 
+        # Recursively go back prev state if current_state has no content
+        if self.current_state.content == "":
+                self.prev_state()
+
     def next_state(self, branch = None):
         """move to next state"""
 
-        if branch:
-            self.current_state = self.current_state.branch[branch]
-        else:
-            self.current_state = self.current_state.next
+        next_state = self.current_state.branch[branch] if branch else self.current_state.next
 
-        if self.current_state.content == "":
-            self.next_state()
+        if next_state:
+            self.current_state = next_state
+
+            # Recursively skip to next state (if exists) if current_state has no content
+            if self.current_state.next and self.current_state.content == "":
+                self.next_state()
 
 
 class TicketHelper(discord.ui.View):

--- a/ticket_helper.py
+++ b/ticket_helper.py
@@ -97,8 +97,11 @@ class StateMachine:
 
 
     def __init__(self):
-        self.start_state = State("start")
-        branch_state = self.start_state.insert_next_state("issue_type").update_content("Choose your issue type:")
+        self.current_state = self.start_state = State("start")
+
+        branch_state = (self.current_state
+                        .insert_next_state("issue_type")
+                        .update_content("Choose your issue type:"))
 
         (branch_state
             .insert_branch_state("general_enquiry")
@@ -138,16 +141,17 @@ class StateMachine:
             .update_data("ticket-id", "11733869435673")
         )
 
-        self.current_state = self.start_state
 
 
     def prev_state(self):
         """move to previous state"""
+
+        assert self.current_state.prev is not None
         self.current_state = self.current_state.prev
 
-        # Recursively go back prev state if current_state has no content
-        if self.current_state.content == "":
-                self.prev_state()
+        # Recursively go back prev state (if exist) if current_state has no content
+        if self.current_state.has_prev() and self.current_state.content == "":
+            self.prev_state()
 
     def next_state(self, branch = None):
         """move to next state"""

--- a/ticket_helper.py
+++ b/ticket_helper.py
@@ -192,12 +192,11 @@ class TicketHelper(discord.ui.View):
         self.clear_items()
 
         if state.name == "issue_type":
-            print('create')
             self.branch_select = discord.ui.Select(placeholder="Issue Type", options=
                     list(map(lambda x: discord.SelectOption(label=x), StateMachine.issue_type_options)))
             self.branch_select.callback = self.branch_next_state
             self.add_item(self.branch_select)
-            self.next_btn.disabled = True
+            # self.next_btn.disabled = True
         else:
             self.branch_select = None
         
@@ -210,10 +209,6 @@ class TicketHelper(discord.ui.View):
             ticket_form_id = state.data["ticket-id"]
             self.link_btn.url = f"{base_url}?ticket_form_id={ticket_form_id}" if ticket_form_id else base_url
             self.add_item(self.link_btn)
-
-        ############################## TESTING ##############################
-        #self.add_item(self.check_btn)
-        ############################## TESTING ##############################
 
 
     def __init__(self):
@@ -228,17 +223,6 @@ class TicketHelper(discord.ui.View):
         self.next_btn.callback = self.go_next_state
 
         self.link_btn = discord.ui.Button(label="Open Ticket",style=discord.ButtonStyle.link, row=4, url=base_url)
-
-        ############################## TESTING ##############################
-        # async def check_curr_state(interaction: discord.Interaction):
-        #    await interaction.response.edit_message(content=self.state_machine.current_state.name)
-            
-        # self.check_btn = discord.ui.Button(label="Check",style=discord.ButtonStyle.danger)
-        # self.check_btn.callback = check_curr_state
-
-
-        self.state_machine.next_state()
-        ############################## TESTING ##############################
 
         self.load_state_ui()
 
@@ -267,7 +251,7 @@ class TicketHelper(discord.ui.View):
         selected_issue_type = self.branch_select.values[0]
         select_branch_state = StateMachine.issue_type_options[selected_issue_type]
         
-        print(select_branch_state)
+        #print(select_branch_state)
         
         #"""
 

--- a/ticket_helper.py
+++ b/ticket_helper.py
@@ -113,20 +113,31 @@ class StateMachine:
         (branch_state
             .insert_branch_state("account_related")
             .insert_next_state("open_ticket")
+            .update_content("You should open a ticket.")
             .update_data("ticket-id", "10970588074137")
         )
 
         (branch_state
             .insert_branch_state("withdrawal_related")
             .insert_next_state("check_processing_days")
+            .update_content(
+                "- Have you checked your estimated withdrawal date using `/calculate_withdrawal`?\n"
+                "- Is the estimated withdrawal date earlier than today?"
+            )
             .insert_next_state("open_ticket")
+            .update_content("You should open a ticket.")
             .update_data("ticket-id", "11749552676121")
         )
 
         (branch_state
             .insert_branch_state("platform_bug")
             .insert_next_state("suggest_discord")
+            .update_content(
+                "You can report in #bug-error-report. "
+                "Otherwise, proceed to open an official report."
+            )
             .insert_next_state("open_ticket")
+            .update_content("You should open a ticket.")
             .update_data("ticket-id", "11733831427737")
         )
 
@@ -138,6 +149,7 @@ class StateMachine:
                 "- Have you discussed with other stackies in #re-review submission?"
             )
             .insert_next_state("open_ticket")
+            .update_content("You should open a ticket.")
             .update_data("ticket-id", "11733869435673")
         )
 


### PR DESCRIPTION
## New Feature

Slash commands to assist in opening a ticket.

By using `/ticket` command, user will be prompted through various checks, depending on the issue type.
At the end, user can click to open a ticket on their browser, with the issue type pre-selected for them.

### What are the benefits of this feature?

With a bot to prompt user of various checks, it reduces the waiting time user typically it takes for a real human to reply. The prompts are common questions that a real human would typically ask when replying to user. The whole interactions is fully ephemeral, keeping the chat history clean.

It also add value by pre-filling the ticket issue type when user opens a ticket on their browser.

#### Example
 Suppose a stackie have not receive their withdrawal after a certain number of days. Typically, they may be unaware of `/calculate_withdrawal` and ask in chat why they have no received. Then, after some (waiting) time, when someone sees the message, they uses `/calculate_withdrawal` and explain to the stackie that its not 7 business days yet.

With `/ticket` command, when user selects "withdrawal" issue, it will prompt and ask the stackie if they have used `/calculate_withdrawal` to see their estimates withdrawal date. It then follows with another prompt (fully customizable) before providing a button to the stackie, which will open the link to submit a withdrawal-matter issue ticket.

### How is it implemented?

`TicketHelper` has an instance of a `StateMachine` to establish and control the progress of the user. Interaction with buttons controls the `StateMachine` to move to/from various states.

`StateMachine` has been customised to this particular use case in `__init__`. The map/hierarchy of the various states are included in file.
<sub>`StateMachine` and `State` is implemented in a way that makes it simple to reconfigure and customise to another use cases with minimal code change.</sub>

### Remarks
- In the prompts, they sometimes reference to certain channels within the server. I had managed to get the channel ID and have included them.
- However, I was unable to get the command ID for `/calculate_withdrawal`, hence could not link it directly.